### PR TITLE
Job Responsibility System / Guests get money over time

### DIFF
--- a/code/game/Game.Debug.cs
+++ b/code/game/Game.Debug.cs
@@ -201,8 +201,9 @@ public partial class CinemaGame
     public static void DebugJobClient()
     {
         if (ConsoleSystem.Caller.Pawn is not Player player) return;
-        Log.Info($"Job: {player.Job.JobDetails.Name}");
+        Log.Info($"Job: {player.Job.Name}");
         // Doing .ToString() makes it so sandbox doesn't add a selectable underline
-        Log.Info($"Abilities: {player.Job.JobDetails.Abilities.ToString()}");
+        Log.Info($"Abilities: {player.Job.Abilities.ToString()}");
+        Log.Info($"Responsibilities: {player.Job.Responsibilities.ToString()}");
     }
 }

--- a/code/jobs/Jobs.cs
+++ b/code/jobs/Jobs.cs
@@ -5,7 +5,7 @@ using Sandbox;
 namespace Cinema.Jobs;
 
 /// <summary>
-/// Traits & Ablities that jobs have
+/// Traits & Abilities that jobs have
 /// </summary>
 [Flags]
 public enum JobAbilities : ulong
@@ -58,6 +58,7 @@ public partial class JobDetails : BaseNetworkable
         {
             Name = "Usher",
             Abilities = JobAbilities.PickupGarbage,
+            Responsibilities = 0,
         }
     };
 }
@@ -71,6 +72,8 @@ public partial class PlayerJob : EntityComponent<Player>, ISingletonComponent
     public new string Name => JobDetails?.Name ?? "Jobless";
 
     public JobAbilities Abilities => JobDetails?.Abilities ?? 0;
+
+    public JobResponsibilities Responsibilities => JobDetails?.Responsibilities ?? 0;
 
     public bool HasAbility(JobAbilities ability) => Abilities.HasFlag(ability);
 

--- a/code/jobs/Jobs.cs
+++ b/code/jobs/Jobs.cs
@@ -32,6 +32,12 @@ public partial class JobDetails : BaseNetworkable
     [Net]
     public JobAbilities Abilities { get; set; }
 
+    /// <summary>
+    /// What responsibilities this job has
+    /// </summary>
+    [Net]
+    public JobResponsibilities Responsibilities { get; set; }
+
     public static JobDetails DefaultJob => All[0];
 
     public static List<JobDetails> All => new()
@@ -43,6 +49,7 @@ public partial class JobDetails : BaseNetworkable
         {
             Name = "Guest",
             Abilities = JobAbilities.Guest | JobAbilities.PurchaseConcessions,
+            Responsibilities = JobResponsibilities.UniversalIncome,
         },
         /// <summary>
         /// Usher job, can pickup garbage

--- a/code/jobs/Responsibilities.cs
+++ b/code/jobs/Responsibilities.cs
@@ -1,0 +1,46 @@
+
+using System;
+using Sandbox;
+
+namespace Cinema.Jobs;
+
+/// <summary>
+/// Responsibilities that jobs have.
+/// If an EntityComponent that derives from `JobResponsibility` exists
+/// With the **exact** same name as the enum, it will be added to the player.
+/// </summary>
+[Flags]
+public enum JobResponsibilities : ulong
+{
+    // Gives you money for playing on the server
+    UniversalIncome = 1 << 0,
+}
+
+public partial class JobResponsibility : EntityComponent<Player>
+{
+    public new virtual string Name => "Responsibility";
+}
+
+public partial class UniversalIncome : JobResponsibility
+{
+    public override string Name => "Universal Income";
+
+    private static int IncomeAmount => 50;
+    private static float IncomeInterval => 60f;
+
+    private TimeUntil TimeUntilNextIncome { get; set; }
+
+    protected override void OnActivate()
+    {
+        TimeUntilNextIncome = IncomeInterval;
+    }
+
+    [GameEvent.Tick.Server]
+    protected void Tick()
+    {
+        if (TimeUntilNextIncome > 0) return;
+
+        TimeUntilNextIncome = IncomeInterval;
+        Entity.AddMoney(IncomeAmount);
+    }
+}

--- a/code/jobs/Responsibilities.cs
+++ b/code/jobs/Responsibilities.cs
@@ -20,27 +20,3 @@ public partial class JobResponsibility : EntityComponent<Player>
 {
     public new virtual string Name => "Responsibility";
 }
-
-public partial class UniversalIncome : JobResponsibility
-{
-    public override string Name => "Universal Income";
-
-    private static int IncomeAmount => 50;
-    private static float IncomeInterval => 60f;
-
-    private TimeUntil TimeUntilNextIncome { get; set; }
-
-    protected override void OnActivate()
-    {
-        TimeUntilNextIncome = IncomeInterval;
-    }
-
-    [GameEvent.Tick.Server]
-    protected void Tick()
-    {
-        if (TimeUntilNextIncome > 0) return;
-
-        TimeUntilNextIncome = IncomeInterval;
-        Entity.AddMoney(IncomeAmount);
-    }
-}

--- a/code/jobs/responsibilities/ubi.cs
+++ b/code/jobs/responsibilities/ubi.cs
@@ -1,0 +1,30 @@
+using Sandbox;
+
+namespace Cinema.Jobs;
+
+public partial class UniversalIncome : JobResponsibility
+{
+    public override string Name => "Universal Income";
+
+    // How much money to give the player every interval
+    private static int IncomeAmount => 10;
+
+    // How long until the player gets money again
+    private static float IncomeInterval => 60f;
+
+    private TimeUntil TimeUntilNextIncome { get; set; }
+
+    protected override void OnActivate()
+    {
+        TimeUntilNextIncome = IncomeInterval;
+    }
+
+    [GameEvent.Tick.Server]
+    protected void Tick()
+    {
+        if (TimeUntilNextIncome > 0) return;
+
+        TimeUntilNextIncome = IncomeInterval;
+        Entity.AddMoney(IncomeAmount);
+    }
+}

--- a/code/player/Player.Jobs.cs
+++ b/code/player/Player.Jobs.cs
@@ -1,3 +1,4 @@
+using System;
 using Sandbox;
 
 namespace Cinema;
@@ -12,6 +13,20 @@ public partial class Player
         if (Game.IsClient) throw new System.Exception("Cannot set job on client!");
 
         Components.RemoveAny<Jobs.PlayerJob>();
+
+        var currentJob = Job.JobDetails;
+        var responsibiltiesToRemove = currentJob.Responsibilities & ~details.Responsibilities;
+        // foreach (var res in responsibiltiesToRemove.GetFlags())
+        // {
+        //     var comp = Components.Remove()
+        //     if (comp != null)
+        //     {
+        //         comp.Remove();
+        //     }
+        // }
+
+        var responsibiltiesToAdd = details.Responsibilities & ~currentJob.Responsibilities;
+
         Components.Add(Jobs.PlayerJob.CreateFromDetails(details));
     }
 }

--- a/code/util/Helpers.cs
+++ b/code/util/Helpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,23 +8,28 @@ namespace Cinema;
 
 public static class Helpers
 {
-	public static IEnumerable<(T item, int index)> WithIndex<T>( this IEnumerable<T> source )
-	{
-		return source.Select( ( item, index ) => (item, index) );
-	}
+    public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> source)
+    {
+        return source.Select((item, index) => (item, index));
+    }
 
-	public static IList<T> Shuffle<T>( this IList<T> list )
-	{
-		var n = list.Count;
-		while ( n > 1 )
-		{
-			n--;
-			var k = Game.Random.Int( 0, n );
-			var value = list[k];
-			list[k] = list[n];
-			list[n] = value;
-		}
+    public static IList<T> Shuffle<T>(this IList<T> list)
+    {
+        var n = list.Count;
+        while (n > 1)
+        {
+            n--;
+            var k = Game.Random.Int(0, n);
+            var value = list[k];
+            list[k] = list[n];
+            list[n] = value;
+        }
 
-		return list;
-	}
+        return list;
+    }
+
+    public static IEnumerable<Enum> GetFlags(this Enum e)
+    {
+        return Enum.GetValues(e.GetType()).Cast<Enum>().Where(e.HasFlag);
+    }
 }


### PR DESCRIPTION
Implemented a system of "Job Responsibilities" similar to "Job Abilities".

Responsibilities are things that the player "needs to do" or could potentially have state. It's also a way of attaching logic to the player based on a job they may have. For instance a player could have the *ability* to pick up trash, but they may or may not have the *responsibility* to put trash in a trash can.

The cool thing about "Job Responsibilities" is that if an Entity Component exists with the same name in the `Cinema.Jobs` namespace, then the component will be created and attached to the player when the player gains that responsibility.

I'm thinking now that perhaps "Job Abilities" could work the same way, and maybe having both is redundant... Let me know what you think!