### PR TITLE
Enhancement of Dev Commands

### DIFF
--- a/code/game/Game.Debug.cs
+++ b/code/game/Game.Debug.cs
@@ -48,7 +48,7 @@ public partial class CinemaGame
         return true;
     }
 
-    [ConCmd.Server("reset.game")]
+    [ConCmd.Server("game.reset")]
     public static void ResetGame()
     {
         if (!ValidateUser(ConsoleSystem.Caller.SteamId)) return;

--- a/code/game/Game.Debug.cs
+++ b/code/game/Game.Debug.cs
@@ -264,7 +264,7 @@ public partial class CinemaGame
         target.SetJob(details);
     }
 
-    [ConCmd.Client("player.job.debug")]
+    [ConCmd.Client("player.job.debug.client")]
     public static void DebugJobClient()
     {
         if (ConsoleSystem.Caller.Pawn is not Player player) return;


### PR DESCRIPTION
I've cleaned up all of the useless crap and simplified the prefix accordingly for every developer command. You no longer have to type the `cinema.` prefix to execute a utility command.

I added a few new ones like `game.reset` and `ent.create`

It should be all straight forward now. You would find your utility commands with such prefixes:
`player.` - Player related stuff
`money.` - Economy stuff (giving money, taking away money)
`game.` - Game commands (map cleanup, etc.)
`ent.` - Entity commands (creation and deletion)