### PR TITLE
Parse Youtube URLs for video ID

### DIFF
--- a/code/ui/movie-queue/MovieQueue.cs
+++ b/code/ui/movie-queue/MovieQueue.cs
@@ -93,7 +93,8 @@ public partial class MovieQueue : Panel
     protected async void OnQueue()
     {
         var videoId = MovieIDEntry.Text;
-        if (videoId == "")
+        videoId = ParseYouTubeIdIfUrl(videoId);
+        if (string.IsNullOrWhiteSpace(videoId))
             return;
         MovieIDEntry.Text = "";
         MovieIDEntry.Disabled = true;
@@ -108,6 +109,47 @@ public partial class MovieQueue : Panel
         }
 
         Controller.RequestMedia(videoId);
+    }
+
+    protected string ParseYouTubeIdIfUrl(string userInput)
+    {
+        var possibleUrl = userInput;
+
+        // If this is clearly a website but missing the URI scheme, add it here.
+        if (userInput.StartsWith("youtu") || userInput.StartsWith("www.youtu"))
+        {
+            possibleUrl = "https://" + userInput;
+        }
+
+        // If we can't make URI from this input, just return the input as-is since it's probably an ID.
+        if (!Uri.TryCreate(possibleUrl, UriKind.Absolute, out Uri uri))
+        {
+            return userInput;
+        }
+        if (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp)
+        {
+            return userInput;
+        }
+
+        // Youtu.be doesn't use a query string and the video ID is just the last part of the path.
+        if (uri.Host.Contains("youtu.be"))
+        {
+            return System.IO.Path.GetFileNameWithoutExtension(uri.LocalPath);
+        }
+        // If this is just some other website, return the input as-is.
+        if (!uri.Host.Contains("youtube"))
+        {
+            return userInput;
+        }
+
+        var queryString = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        var videoIdParam = queryString["v"];
+        if (string.IsNullOrEmpty(videoIdParam))
+        {
+            Log.Error("No video ID in URL");
+            return null;
+        }
+        return videoIdParam;
     }
 
     protected void OnSkip()


### PR DESCRIPTION
This change adds support for adding videos using Youtube URLs, including the shortened youtu.be URLs. 

Related issue: https://github.com/tech-nawar/sbox-cinema/issues/46