### PR TITLE
Remove solid tag for projectiles

### DIFF
--- a/code/entities/Projectile.cs
+++ b/code/entities/Projectile.cs
@@ -10,6 +10,8 @@ public class Projectile : Prop
     {
         base.Spawn();
         SetupPhysicsFromModel(PhysicsMotionType.Dynamic);
+        // Remove the solid tag so that the projectile doesn't collide with the owner.
+        Tags.Remove("solid");
     }
 
     [GameEvent.Tick.Server]


### PR DESCRIPTION
By removing the solid tag, the player will no longer suddenly halt when spawning projectiles that overlap them. Players may still push garbage around by walking through it, but they will no longer be halted by doing so. This is probably a more realistic representation of what it's like to walk through a pile of empty containers anyway.

This is a fix for: https://github.com/tech-nawar/sbox-cinema/issues/23

https://github.com/tech-nawar/sbox-cinema/assets/8889285/170871be-9bf9-41d4-a164-5e7024bbfd59

