### PR TITLE
Enhancements and fixes to food and beverage launching

### DIFF
--- a/code/entities/Projectile.cs
+++ b/code/entities/Projectile.cs
@@ -4,27 +4,78 @@ namespace Cinema;
 
 public class Projectile : Prop
 {
+    /// <summary>
+    /// In cases where it makes sense for a projectile to automatically break
+    /// apart after being launched, this should be set to true.
+    /// </summary>
+    public bool BreakAfterLaunch { get; init; } = false;
+    /// <summary>
+    /// Specifies the amount of time that must pass before the projectile automatically
+    /// breaks from being launched. If this is set to a negative value, then the projectile
+    /// will break after only a very short delay.
+    /// </summary>
+    public float TimeUntilBreak { get; set; } = -1f;
+
+    /// <summary>
+    /// Because we assume that a projectile is launched as soon as it is spawned,
+    /// this is analogous to air time.
+    /// </summary>
+    protected TimeSince TimeSinceSpawned { get; set; }
+
     private static float VelocityToBreak => 120;
 
     public override void Spawn()
     {
         base.Spawn();
         SetupPhysicsFromModel(PhysicsMotionType.Dynamic);
+        // We assume that the projectile is in flight from the moment it is spawned.
+        TimeSinceSpawned = 0f;
+        if (TimeUntilBreak < 0f)
+        {
+            TimeUntilBreak = 0.05f;
+        }
+    }
+
+    public void LaunchFromEntityViewpoint(Entity entity, float speedFactor = 1.0f)
+    {
+        Owner = entity;
+        entity ??= this;
+
+        var forward = entity.AimRay.Forward;
+
+        Position = entity.AimRay.Position + forward * 5.0f;
+        Rotation = Rotation.LookAt(forward);
+
+        var forwardVelocity = forward * 450.0f * speedFactor;
+        var upwardVelocity = entity.Rotation.Up * 250.0f * speedFactor;
+        PhysicsBody.Velocity = forwardVelocity + upwardVelocity;
+        PhysicsBody.AngularVelocity = forward + Vector3.Random * 15;
     }
 
     [GameEvent.Tick.Server]
     protected void Tick()
     {
-
+        // If projectile breaks after launch, check if it's time to do so.
+        if (BreakAfterLaunch && TimeSinceSpawned >= TimeUntilBreak)
+        {
+            Break();
+        }
     }
 
     protected override void OnPhysicsCollision(CollisionEventData eventData)
     {
-        base.OnPhysicsCollision(eventData);
+        // Prevent the projectile from immediately breaking on the person who threw it.
+        if (TimeSinceSpawned < 0.25f && eventData.Other.Entity == Owner)
+            return;
 
-        if (eventData.Other.Entity is not WorldEntity || eventData.Other.Entity == this) return;
-
+        // If the projectile is moving fast enough, break it.
         if (eventData.This.PreVelocity.Length > VelocityToBreak)
+        {
             Break();
+            return;
+        }
+
+        // Finally, look for any other reasons this projectile might break.
+        base.OnPhysicsCollision(eventData);
     }
 }

--- a/code/entities/weapons/fnb/Hotdog.cs
+++ b/code/entities/weapons/fnb/Hotdog.cs
@@ -32,14 +32,10 @@ public partial class Hotdog : WeaponBase
         {
             var projectile = new Projectile()
             {
-                Owner = WeaponHolder,
-                Model = Model.Load("models/hotdog/w_hotdog_boxed.vmdl"),
-                Position = WeaponHolder.AimRay.Position + WeaponHolder.AimRay.Forward * 5.0f,
-                Rotation = WeaponHolder.EyeRotation,
+                Model = Model.Load("models/hotdog/w_hotdog_boxed.vmdl")
             };
 
-            projectile.PhysicsBody.Velocity = WeaponHolder.AimRay.Forward * 450.0f + WeaponHolder.Rotation.Up * 250.0f;
-            projectile.PhysicsBody.AngularVelocity = WeaponHolder.EyeRotation.Forward + Vector3.Random * 15;
+            projectile.LaunchFromEntityViewpoint(WeaponHolder);
         }
     }
 

--- a/code/entities/weapons/fnb/Nachos.cs
+++ b/code/entities/weapons/fnb/Nachos.cs
@@ -32,14 +32,11 @@ public partial class Nachos : WeaponBase
         {
             var projectile = new Projectile()
             {
-                Owner = WeaponHolder,
                 Model = Model.Load("models/nachos_tray/nachos_tray.vmdl"),
-                Position = WeaponHolder.AimRay.Position + WeaponHolder.AimRay.Forward * 5.0f,
-                Rotation = WeaponHolder.EyeRotation,
+                BreakAfterLaunch = true
             };
 
-            projectile.PhysicsBody.Velocity = WeaponHolder.AimRay.Forward * 450.0f + WeaponHolder.Rotation.Up * 250.0f;
-            projectile.PhysicsBody.AngularVelocity = WeaponHolder.EyeRotation.Forward + Vector3.Random * 15;
+            projectile.LaunchFromEntityViewpoint(WeaponHolder);
         }
     }
 

--- a/code/entities/weapons/fnb/Popcorn.cs
+++ b/code/entities/weapons/fnb/Popcorn.cs
@@ -32,14 +32,10 @@ public partial class Popcorn : WeaponBase
         {
             var projectile = new Projectile()
             {
-                Owner = WeaponHolder,
                 Model = Model.Load("models/popcorn_tub/w_popcorn_tub_01.vmdl"),
-                Position = WeaponHolder.AimRay.Position + WeaponHolder.AimRay.Forward * 5.0f,
-                Rotation = WeaponHolder.EyeRotation,
             };
 
-            projectile.PhysicsBody.Velocity = WeaponHolder.AimRay.Forward * 450.0f + WeaponHolder.Rotation.Up * 250.0f;
-            projectile.PhysicsBody.AngularVelocity = WeaponHolder.EyeRotation.Forward + Vector3.Random * 15;
+            projectile.LaunchFromEntityViewpoint(WeaponHolder);
         }
     }
 

--- a/code/entities/weapons/fnb/Soda.cs
+++ b/code/entities/weapons/fnb/Soda.cs
@@ -32,14 +32,10 @@ public partial class Soda : WeaponBase
         {
             var projectile = new Projectile()
             {
-                Owner = WeaponHolder,
                 Model = Model.Load("models/papercup/papercup.vmdl"),
-                Position = WeaponHolder.AimRay.Position + WeaponHolder.AimRay.Forward * 5.0f,
-                Rotation = WeaponHolder.EyeRotation,
             };
 
-            projectile.PhysicsBody.Velocity = WeaponHolder.AimRay.Forward * 450.0f + WeaponHolder.Rotation.Up * 250.0f;
-            projectile.PhysicsBody.AngularVelocity = WeaponHolder.EyeRotation.Forward + Vector3.Random * 15;
+            projectile.LaunchFromEntityViewpoint(WeaponHolder);
         }
     }
 

--- a/code/player/controllers/ChairController.cs
+++ b/code/player/controllers/ChairController.cs
@@ -65,10 +65,11 @@ public partial class ChairController : PlayerController
 
     private void PrimeTest(Armrest.Sides side)
     {
-        var cup = new ModelEntity("models/papercup/papercup.vmdl");
-        cup.Tags.Add("solid");
-        cup.SetupPhysicsFromModel(PhysicsMotionType.Dynamic);
-        Chair.Armrests[side]?.TryHoldEntity(cup);
+        var projectile = new Projectile()
+        {
+            Model = Model.Load("models/papercup/papercup.vmdl")
+        };
+        Chair.Armrests[side]?.TryHoldEntity(projectile);
     }
 
     private void SimulateAnimation()


### PR DESCRIPTION
This PR introduces the following changes:

- Added `Projectile.BreakAfterLaunch` and `Projectile.TimeUntilBreak`, which configure a feature where projectiles automatically break after being spawned.
- Nachos now break after launch - the chips will fly all over the place when you throw the tray, which is what would actually happen if you threw a tray of nachos.
https://github.com/tech-nawar/sbox-cinema/assets/8889285/720e2ca0-ac78-49f4-ac98-caf56331e11d
- Added `Projectile.LaunchFromEntityViewpoint` to remove some of the copy-pasted code from the FNB entity classes.
- Thrown food and beverages now collide with non-world entities, but won't collide with the player who spawned them until a quarter of a second after being spawned.
- `cinema.chair.debug` now causes instances of `Projectile` to get held in the cupholders, which is probably how we'll implement actually inserting cups.