### PR TITLE
Fix weird eye position in cinema chair

### DIFF
--- a/code/entities/Projectile.cs
+++ b/code/entities/Projectile.cs
@@ -22,6 +22,10 @@ public class Projectile : Prop
 
     protected override void OnPhysicsCollision(CollisionEventData eventData)
     {
+        // Don't break on the chair you're sitting in.
+        if (eventData.Other.Entity is CinemaChair chair && chair.Occupant == Owner)
+            return;
+
         base.OnPhysicsCollision(eventData);
 
         if (eventData.Other.Entity is not WorldEntity || eventData.Other.Entity == this) return;

--- a/code/player/controllers/ChairController.cs
+++ b/code/player/controllers/ChairController.cs
@@ -97,8 +97,8 @@ public partial class ChairController : PlayerController
         LookInput = (LookInput + Input.AnalogLook).Normal;
         LookInput = LookInput.WithPitch(LookInput.pitch.Clamp(-90f, 90f));
 
-        var eyeAttachment = Entity.GetAttachment("eyes");
-        LookPosition = eyeAttachment.Value.Position;
+        var eyeOffset = new Vector3(-6, 0, 40);
+        LookPosition = Entity.Transform.PointToWorld(eyeOffset);
 
         if (ChairDebug && Chair.IsValid())
         {


### PR DESCRIPTION
Using the eye attachment of the player to determine their EyeLocalPosition was causing the position of the first person camera to appear very incorrect when holding food, and _very_ incorrect when holding food while crouching. This change fixes that problem, which is described further in: https://github.com/tech-nawar/sbox-cinema/issues/20