### PR TITLE
CinemaChair: use physics from model

### DIFF
--- a/code/entities/chair/CinemaChair.cs
+++ b/code/entities/chair/CinemaChair.cs
@@ -86,7 +86,7 @@ public partial class CinemaChair : AnimatedEntity, ICinemaUse
             new Vector3(0, 0, 64),
             16f
             );
-        SetupPhysicsFromCapsule(PhysicsMotionType.Keyframed, capsule);
+        SetupPhysicsFromModel(PhysicsMotionType.Keyframed);
 
         Armrests[Armrest.Sides.Left] = new Armrest()
         {


### PR DESCRIPTION
I added physics shapes to the cinema chair model. This change is to make the code use those shapes instead of making a big invisible capsule.

<img width="305" alt="image" src="https://github.com/tech-nawar/sbox-cinema/assets/8889285/321950ec-3814-4604-a907-19e6f9fce4cb">
