### PR TITLE
Weapon removal changes

### DIFF
--- a/.addon
+++ b/.addon
@@ -7,7 +7,8 @@
   "Schema": 1,
   "HasAssets": true,
   "AssetsPath": "",
-  "ResourcePaths": [],
+  "Resources": null,
+  "MenuResources": null,
   "HasCode": true,
   "CodePath": "/code/",
   "PackageReferences": [
@@ -36,6 +37,191 @@
       "NoWarn": "1701;1702;1591;",
       "References": [],
       "DistinctReferences": []
+    },
+    "ControlModes": {
+      "Keyboard": true
+    },
+    "InputSettings": {
+      "Actions": [
+        {
+          "Name": "Forward",
+          "KeyboardCode": "W",
+          "GroupName": "Movement"
+        },
+        {
+          "Name": "Backward",
+          "KeyboardCode": "S",
+          "GroupName": "Movement"
+        },
+        {
+          "Name": "Left",
+          "KeyboardCode": "A",
+          "GroupName": "Movement"
+        },
+        {
+          "Name": "Right",
+          "KeyboardCode": "D",
+          "GroupName": "Movement"
+        },
+        {
+          "Name": "Jump",
+          "KeyboardCode": "space",
+          "GamepadCode": "A",
+          "GroupName": "Movement"
+        },
+        {
+          "Name": "Run",
+          "KeyboardCode": "shift",
+          "GamepadCode": "LeftJoystickButton",
+          "GroupName": "Movement"
+        },
+        {
+          "Name": "Walk",
+          "KeyboardCode": "alt",
+          "GroupName": "Movement"
+        },
+        {
+          "Name": "Duck",
+          "KeyboardCode": "ctrl",
+          "GamepadCode": "B",
+          "GroupName": "Movement"
+        },
+        {
+          "Name": "attack1",
+          "KeyboardCode": "mouse1",
+          "GamepadCode": "RightTrigger",
+          "GroupName": "Actions"
+        },
+        {
+          "Name": "attack2",
+          "KeyboardCode": "mouse2",
+          "GamepadCode": "LeftTrigger",
+          "GroupName": "Actions"
+        },
+        {
+          "Name": "reload",
+          "KeyboardCode": "r",
+          "GamepadCode": "X",
+          "GroupName": "Actions"
+        },
+        {
+          "Name": "use",
+          "KeyboardCode": "e",
+          "GamepadCode": "Y",
+          "GroupName": "Actions"
+        },
+        {
+          "Name": "Slot1",
+          "KeyboardCode": "1",
+          "GamepadCode": "DpadWest",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot2",
+          "KeyboardCode": "2",
+          "GamepadCode": "DpadEast",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot3",
+          "KeyboardCode": "3",
+          "GamepadCode": "DpadSouth",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot4",
+          "KeyboardCode": "4",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot5",
+          "KeyboardCode": "5",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot6",
+          "KeyboardCode": "6",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot7",
+          "KeyboardCode": "7",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot8",
+          "KeyboardCode": "8",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot9",
+          "KeyboardCode": "9",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "Slot0",
+          "KeyboardCode": "0",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "SlotPrev",
+          "KeyboardCode": "mouse4",
+          "GamepadCode": "SwitchLeftBumper",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "SlotNext",
+          "KeyboardCode": "mouse5",
+          "GamepadCode": "SwitchRightBumper",
+          "GroupName": "Inventory"
+        },
+        {
+          "Name": "View",
+          "KeyboardCode": "C",
+          "GamepadCode": "RightJoystickButton",
+          "GroupName": "Other"
+        },
+        {
+          "Name": "Voice",
+          "KeyboardCode": "v",
+          "GamepadCode": "RightJoystickButton",
+          "GroupName": "Other"
+        },
+        {
+          "Name": "Drop",
+          "KeyboardCode": "g",
+          "GamepadCode": "RightJoystickButton",
+          "GroupName": "Other"
+        },
+        {
+          "Name": "Flashlight",
+          "KeyboardCode": "f",
+          "GamepadCode": "DpadNorth",
+          "GroupName": "Other"
+        },
+        {
+          "Name": "Score",
+          "KeyboardCode": "tab",
+          "GamepadCode": "SwitchLeftMenu",
+          "GroupName": "Other"
+        },
+        {
+          "Name": "Menu",
+          "KeyboardCode": "Q",
+          "GamepadCode": "SwitchRightMenu",
+          "GroupName": "Other"
+        },
+        {
+          "Name": "Chat",
+          "KeyboardCode": "enter",
+          "GroupName": "Other"
+        },
+        {
+          "Name": "Holster",
+          "KeyboardCode": "H",
+          "GroupName": "Other"
+        }
+      ]
     }
   }
 }

--- a/code/entities/weapons/WeaponBase.cs
+++ b/code/entities/weapons/WeaponBase.cs
@@ -1,4 +1,5 @@
 ﻿using Sandbox;
+using System.Linq;
 
 namespace Cinema;
 
@@ -37,6 +38,12 @@ public partial class WeaponBase : Carriable
     public override void Simulate(IClient cl)
     {
         base.Simulate(cl);
+
+        if (CanHolster())
+        {
+            Holster();
+            return;
+        }
 
         //If the holder is reloading, wait until the reload is finished
         if (IsReloading)
@@ -111,6 +118,11 @@ public partial class WeaponBase : Carriable
         return !IsReloading && Input.Pressed("reload");
     }
 
+    public virtual bool CanHolster()
+    {
+        return Input.Pressed("holster");
+    }
+
     //Primary fire
     public virtual void PrimaryFire()
     {
@@ -132,6 +144,11 @@ public partial class WeaponBase : Carriable
     {
         IsReloading = true;
         ReloadTime = ReloadingTime;
+    }
+
+    public virtual void Holster()
+    {
+        WeaponHolder.ActiveChild = null;
     }
 
     //Finishes reloading
@@ -166,6 +183,26 @@ public partial class WeaponBase : Carriable
         ViewModelEntity.Owner = Owner;
         ViewModelEntity.EnableViewmodelRendering = true;
         ViewModelEntity.SetModel(ViewModelPath);
+    }
+
+    public void RemoveFromHolder()
+    {
+        if (!WeaponHolder.IsValid())
+            return;
+
+        WeaponHolder.Inventory.RemoveWeapon(this, false);
+        // Get the next weapon of the same type
+        var nextWeapon = WeaponHolder
+            .Inventory
+            .Weapons
+            .FirstOrDefault(w => (w as WeaponBase).Name == this.Name);
+        // If there is no next weapon of the same type, just get whatever's left.
+        if (nextWeapon == null)
+        {
+            nextWeapon = WeaponHolder.Inventory.GetBestWeapon();
+        }
+        // Set the active weapon to whatever weapon we found.
+        WeaponHolder.ActiveChild = nextWeapon;
     }
 }
 

--- a/code/entities/weapons/fnb/Hotdog.cs
+++ b/code/entities/weapons/fnb/Hotdog.cs
@@ -40,6 +40,8 @@ public partial class Hotdog : WeaponBase
 
             projectile.PhysicsBody.Velocity = WeaponHolder.AimRay.Forward * 450.0f + WeaponHolder.Rotation.Up * 250.0f;
             projectile.PhysicsBody.AngularVelocity = WeaponHolder.EyeRotation.Forward + Vector3.Random * 15;
+
+            RemoveFromHolder();
         }
     }
 

--- a/code/entities/weapons/fnb/Nachos.cs
+++ b/code/entities/weapons/fnb/Nachos.cs
@@ -40,6 +40,8 @@ public partial class Nachos : WeaponBase
 
             projectile.PhysicsBody.Velocity = WeaponHolder.AimRay.Forward * 450.0f + WeaponHolder.Rotation.Up * 250.0f;
             projectile.PhysicsBody.AngularVelocity = WeaponHolder.EyeRotation.Forward + Vector3.Random * 15;
+
+            RemoveFromHolder();
         }
     }
 

--- a/code/entities/weapons/fnb/Popcorn.cs
+++ b/code/entities/weapons/fnb/Popcorn.cs
@@ -40,6 +40,8 @@ public partial class Popcorn : WeaponBase
 
             projectile.PhysicsBody.Velocity = WeaponHolder.AimRay.Forward * 450.0f + WeaponHolder.Rotation.Up * 250.0f;
             projectile.PhysicsBody.AngularVelocity = WeaponHolder.EyeRotation.Forward + Vector3.Random * 15;
+
+            RemoveFromHolder();
         }
     }
 

--- a/code/entities/weapons/fnb/Soda.cs
+++ b/code/entities/weapons/fnb/Soda.cs
@@ -40,6 +40,8 @@ public partial class Soda : WeaponBase
 
             projectile.PhysicsBody.Velocity = WeaponHolder.AimRay.Forward * 450.0f + WeaponHolder.Rotation.Up * 250.0f;
             projectile.PhysicsBody.AngularVelocity = WeaponHolder.EyeRotation.Forward + Vector3.Random * 15;
+
+            RemoveFromHolder();
         }
     }
 

--- a/code/game/Game.Debug.cs
+++ b/code/game/Game.Debug.cs
@@ -8,6 +8,11 @@ public partial class CinemaGame
 {
     public static bool ValidateUser(long steamID) => true;
 
+    private static IClient GetPlayer(string query)
+        => Game.Clients.FirstOrDefault(
+                cl => cl.Name.ToLower().Contains(query.ToLower())
+            );
+
     [ClientRpc]
     public static void CleanupClientEntities()
     {
@@ -284,5 +289,23 @@ public partial class CinemaGame
                 status = $"In Menu ({localPawn.ActiveMenuName})";
             Log.Info($"{client} - {status}");
         }
+    }
+
+    [ConCmd.Server("player.strip.weapons")]
+    public static void StripWeapons(string playerName)
+    {
+        if (!ValidateUser(ConsoleSystem.Caller.SteamId)) return;
+
+        var client = GetPlayer(playerName);
+
+        if (client?.Pawn is not Player player)
+            return;
+
+        player
+            .Inventory
+            .Weapons
+            .OfType<WeaponBase>()
+            .ToList()
+            .ForEach(w => w.RemoveFromHolder());
     }
 }


### PR DESCRIPTION
This PR adds the following features:

- Thrown weapons will automatically be removed from the player's inventory via the new `WeaponBase.RemoveFromHolder()` method.
  - After removing a weapon, the next weapon of the same type (e.g. "popcorn" or "soda") will be equipped.
  - If no weapon of the same type is found, then the next weapon of any type will be used.
  - If no weapons of any type are found, the player will simply be left empty-handed.
- The player may now holster their active weapon by pressing the `H` key on their keyboard
  - This corresponds to the `holster` input action
- Added the `player.strip.weapons` command, which destroys all weapons held by a specified player. 