### PR TITLE
Add usher uniform

### DIFF
--- a/.addon
+++ b/.addon
@@ -1,13 +1,14 @@
 {
   "Title": "Cinema",
   "Type": "game",
-  "Org": "local",
+  "Org": "cinemateam",
   "Ident": "cinema",
   "Tags": null,
   "Schema": 1,
   "HasAssets": true,
   "AssetsPath": "",
-  "ResourcePaths": [],
+  "Resources": null,
+  "MenuResources": null,
   "HasCode": true,
   "CodePath": "/code/",
   "PackageReferences": [

--- a/code/entities/npc/NpcBase.cs
+++ b/code/entities/npc/NpcBase.cs
@@ -13,6 +13,10 @@ public partial class NpcBase : AnimatedEntity, ICinemaUse
     /// Description of the NPC, displayed over head
     /// </summary>
     public virtual string Description => "";
+    /// <summary>
+    /// The name of an outfit resource that will be worn by this NPC when it spawns.
+    /// If null, the NPC will be naked.
+    /// </summary>
     public virtual string Uniform => "usher";
     /// <summary>
     /// Whether using the NPC is toggleable

--- a/code/entities/npc/NpcBase.cs
+++ b/code/entities/npc/NpcBase.cs
@@ -13,6 +13,7 @@ public partial class NpcBase : AnimatedEntity, ICinemaUse
     /// Description of the NPC, displayed over head
     /// </summary>
     public virtual string Description => "";
+    public virtual string Uniform => "usher";
     /// <summary>
     /// Whether using the NPC is toggleable
     /// </summary>
@@ -26,6 +27,12 @@ public partial class NpcBase : AnimatedEntity, ICinemaUse
 
         SetModel("models/citizen/citizen.vmdl");
         SetupPhysicsFromAABB(PhysicsMotionType.Keyframed, new Vector3(-16, -16, 0), new Vector3(16, 16, 72));
+        var uniform = JobUniform.Get(Uniform);
+        if (uniform != null)
+        {
+            var uniformClothing = uniform.GetOutfit(null);
+            uniformClothing.DressEntity(this);
+        }
     }
 
     public override void ClientSpawn()

--- a/code/game/Game.Debug.cs
+++ b/code/game/Game.Debug.cs
@@ -112,6 +112,7 @@ public partial class CinemaGame
         var ent = TypeLibrary.Create<Entity>(entityType);
 
         ent.Position = tr.EndPosition;
+        // Make the spawned entity face the player who spawned it.
         ent.Rotation = Rotation.From(new Angles(0, (-owner.AimRay.Forward).EulerAngles.yaw, 0));
     }
 

--- a/code/game/Game.Debug.cs
+++ b/code/game/Game.Debug.cs
@@ -112,7 +112,7 @@ public partial class CinemaGame
         var ent = TypeLibrary.Create<Entity>(entityType);
 
         ent.Position = tr.EndPosition;
-        ent.Rotation = Rotation.From(new Angles(0, owner.AimRay.Forward.EulerAngles.yaw, 0));
+        ent.Rotation = Rotation.From(new Angles(0, (-owner.AimRay.Forward).EulerAngles.yaw, 0));
     }
 
     [ConCmd.Server("weapon.create")]

--- a/code/jobs/JobEvents.cs
+++ b/code/jobs/JobEvents.cs
@@ -8,10 +8,17 @@ using System.Threading.Tasks;
 
 namespace Cinema;
 
+/// <summary>
+/// Holds events specific to the Cinema game.
+/// </summary>
 public static partial class CinemaEvent
 {
     public const string JobChanged = "job.changed";
 
+    /// <summary>
+    /// Runs on the client and server whenever a player's job changes. The
+    /// only argument is the <c>Player</c> whose job had changed.
+    /// </summary>
     [MethodArguments(typeof( Player ))]
     public class JobChangedAttribute : EventAttribute
     {

--- a/code/jobs/JobEvents.cs
+++ b/code/jobs/JobEvents.cs
@@ -1,0 +1,20 @@
+﻿using Cinema.Jobs;
+using Sandbox;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cinema;
+
+public static partial class CinemaEvent
+{
+    public const string JobChanged = "job.changed";
+
+    [MethodArguments(typeof( Player ))]
+    public class JobChangedAttribute : EventAttribute
+    {
+        public JobChangedAttribute() : base(JobChanged) { }
+    }
+}

--- a/code/jobs/JobUniform.cs
+++ b/code/jobs/JobUniform.cs
@@ -1,0 +1,68 @@
+﻿using Cinema.Jobs;
+using Sandbox;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cinema;
+
+[GameResource(title: "Uniform Definition", extension: "uniform", 
+    description: "Defines an outfit that is worn by a specific job, which will be used to replace the existing clothes worn by a player.", 
+    Icon = "checkroom")]
+public class JobUniform : GameResource
+{
+    /// <summary>
+    /// The clothing that will be worn by a player or NPC who wears this outfit.
+    /// </summary>
+    [ResourceType("clothing")]
+    public List<string> Clothing { get; set; }
+    /// <summary>
+    /// If true, hats will replace hair. If false, hats will be added on top of hair.
+    /// </summary>
+    public bool HatShouldReplaceHair { get; set; } = true;
+
+    public static JobUniform Get(string name)
+    {
+        var uniformName = name.Split('.').First();
+        return ResourceLibrary
+            .GetAll<JobUniform>()
+            .Where(u => System.IO.Path.GetFileNameWithoutExtension(u.ResourcePath) == uniformName)
+            .FirstOrDefault();
+    }
+
+    public ClothingContainer GetOutfit(ClothingContainer existing = null)
+    {
+        var finalClothing = new ClothingContainer();
+
+        if (existing != null)
+        {
+            foreach (var clothing in existing.Clothing)
+            {
+                finalClothing.Add(clothing);
+            }
+        }
+        foreach (var clothingPath in Clothing)
+        {
+            var article = ResourceLibrary.Get<Clothing>(clothingPath);
+            if (!HatShouldReplaceHair && article.Category == Sandbox.Clothing.ClothingCategory.Hat)
+            {
+                // If we force hats to replace hair, we're still removing existing hats,
+                // so do that manually here.
+                var hats = finalClothing
+                    .Clothing
+                    .Where(c => c.Category == Sandbox.Clothing.ClothingCategory.Hat && c.SubCategory != "glasses")
+                    .ToList();
+                foreach (var hat in hats)
+                {
+                    finalClothing.Remove(hat);
+                }
+                finalClothing.ForceAdd(article);
+                continue;
+            }
+            finalClothing.Add(article);
+        }
+        return finalClothing;
+    }
+}

--- a/code/jobs/JobUniform.cs
+++ b/code/jobs/JobUniform.cs
@@ -23,6 +23,10 @@ public class JobUniform : GameResource
     /// </summary>
     public bool HatShouldReplaceHair { get; set; } = true;
 
+    /// <summary>
+    /// Returns the uniform with the given name, or null if no such uniform exists.
+    /// </summary>
+    /// <param name="name">A filename without an extension.</param>
     public static JobUniform Get(string name)
     {
         var uniformName = name.Split('.').First();
@@ -32,6 +36,12 @@ public class JobUniform : GameResource
             .FirstOrDefault();
     }
 
+    /// <summary>
+    /// Returns a <c>ClothingContainer</c> that represents the outfit that will be worn by a 
+    /// player or NPC who wears this uniform. If <paramref name="existing"/> is set, the clothing
+    /// from that <c>ClothingContainer</c> will be added to the returned <c>ClothingContainer</c>.
+    /// </summary>
+    /// <param name="existing">An existing set of clothing that shall be merged with the outfit.</param>
     public ClothingContainer GetOutfit(ClothingContainer existing = null)
     {
         var finalClothing = new ClothingContainer();

--- a/code/jobs/Jobs.cs
+++ b/code/jobs/Jobs.cs
@@ -43,7 +43,7 @@ public partial class JobDetails : BaseNetworkable
 
     /// <summary>
     /// The set of clothing that will automatically be applied to any player
-    /// who selects this job.
+    /// who selects this job. If null, the player's avatar clothing will be use.
     /// </summary>
     [Net]
     public string Uniform { get; set; }
@@ -113,6 +113,8 @@ public partial class PlayerJob : EntityComponent<Player>, ISingletonComponent
     {
         base.OnActivate();
 
+        // It is assumed that whenever this component is activated on a player, their job
+        // is being changed to the job described by this component.
         Event.Run(CinemaEvent.JobChanged, Entity);
     }
 }

--- a/code/jobs/Jobs.cs
+++ b/code/jobs/Jobs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Sandbox;
 
 namespace Cinema.Jobs;
@@ -40,6 +41,13 @@ public partial class JobDetails : BaseNetworkable
     [Net]
     public JobResponsibilities Responsibilities { get; set; }
 
+    /// <summary>
+    /// The set of clothing that will automatically be applied to any player
+    /// who selects this job.
+    /// </summary>
+    [Net]
+    public string Uniform { get; set; }
+
     public static JobDetails DefaultJob => All[0];
 
     public static List<JobDetails> All => new()
@@ -61,6 +69,7 @@ public partial class JobDetails : BaseNetworkable
             Name = "Usher",
             Abilities = JobAbilities.PickupGarbage,
             Responsibilities = 0,
+            Uniform = "usher"
         },
         /// <summary>
         /// Concession worker who can make and store popcorn
@@ -68,7 +77,8 @@ public partial class JobDetails : BaseNetworkable
         new JobDetails {
             Name = "Concession Worker",
             Abilities = JobAbilities.MakePopcorn,
-            Responsibilities = JobResponsibilities.PopcornStocking
+            Responsibilities = JobResponsibilities.PopcornStocking,
+            Uniform = "usher"
         }
     };
 }
@@ -97,5 +107,12 @@ public partial class PlayerJob : EntityComponent<Player>, ISingletonComponent
         };
 
         return job;
+    }
+
+    protected override void OnActivate()
+    {
+        base.OnActivate();
+
+        Event.Run(CinemaEvent.JobChanged, Entity);
     }
 }

--- a/code/player/Player.Clothing.cs
+++ b/code/player/Player.Clothing.cs
@@ -1,4 +1,5 @@
 using Sandbox;
+using System.Linq;
 
 namespace Cinema;
 
@@ -7,24 +8,38 @@ public partial class Player
     [Net]
     public string ClothingAsString { get; set; }
 
-    public ClothingContainer Clothing { get; protected set; }
+    /// <summary>
+    /// The clothing that the player chosen for themself in the avatar editor.
+    /// </summary>
+    public ClothingContainer AvatarClothing { get; protected set; }
 
     /// <summary>
     /// Dresses the player entity.
     /// It will load the player's clothing from the client data if it hasn't been loaded yet.
     /// </summary>
-    public void LoadClothing()
+    public void LoadAvatarClothing()
     {
         if (Client == null || !Client.IsValid) return;
 
-        if (Clothing == null)
+        Undress();
+
+        if (AvatarClothing == null)
         {
-            Clothing ??= new();
-            Clothing.LoadFromClient(Client);
+            AvatarClothing ??= new();
+            AvatarClothing.LoadFromClient(Client);
             ClothingAsString = Client.GetClientData("avatar", "");
         }
 
-        Clothing.DressEntity(this);
+        AvatarClothing.DressEntity(this);
+    }
+
+    public void Undress()
+    {
+        var clothing = Children.Where(e => e.Tags.Has("clothes")).ToList();
+        for (int i = 0; i < clothing.Count; i++)
+        {
+            clothing[i].Delete();
+        }
     }
 
 }

--- a/code/player/Player.Clothing.cs
+++ b/code/player/Player.Clothing.cs
@@ -40,6 +40,11 @@ public partial class Player
         {
             clothing[i].Delete();
         }
+        var bodyPartCount = Model.BodyPartCount;
+        for (int i = 0; i < bodyPartCount; i++)
+        {
+            SetBodyGroup(i, 1);
+        }
     }
 
 }

--- a/code/player/Player.Clothing.cs
+++ b/code/player/Player.Clothing.cs
@@ -33,6 +33,9 @@ public partial class Player
         AvatarClothing.DressEntity(this);
     }
 
+    /// <summary>
+    /// Deletes all clothing currently worn by a player and makes all body groups visible.
+    /// </summary>
     public void Undress()
     {
         var clothing = Children.Where(e => e.Tags.Has("clothes")).ToList();

--- a/code/player/Player.Jobs.cs
+++ b/code/player/Player.Jobs.cs
@@ -6,22 +6,24 @@ namespace Cinema;
 public partial class Player
 {
     [BindComponent]
-    public Jobs.PlayerJob Job { get; }
+    public PlayerJob Job { get; }
 
-    public void SetJob(Jobs.JobDetails newJob)
+    public void SetJob(JobDetails newJob)
     {
         if (Game.IsClient) throw new System.Exception("Cannot set job on client!");
 
         UpdateResponsibilities(newJob.Responsibilities);
 
-        Components.RemoveAny<Jobs.PlayerJob>();
-        Components.Add(Jobs.PlayerJob.CreateFromDetails(newJob));
+        Components.RemoveAny<PlayerJob>();
+        Components.Add(PlayerJob.CreateFromDetails(newJob));
 
         if (Job.JobDetails.Uniform == null)
         {
             LoadAvatarClothing();
             return;
         }
+
+        Undress();
 
         var jobUniform = JobUniform.Get(Job.JobDetails.Uniform);
         if (jobUniform == null)
@@ -30,8 +32,6 @@ public partial class Player
             return;
         }
 
-        // Delete existing clothing so we don't overlap.
-        Undress();
         var uniformOutfit = jobUniform.GetOutfit(AvatarClothing);
         uniformOutfit.DressEntity(this);
     }

--- a/code/player/Player.Jobs.cs
+++ b/code/player/Player.Jobs.cs
@@ -23,14 +23,14 @@ public partial class Player
             return;
         }
 
-        Undress();
-
         var jobUniform = JobUniform.Get(Job.JobDetails.Uniform);
         if (jobUniform == null)
         {
             Log.Error($"Could not find uniform with name: {Job.JobDetails.Uniform}");
             return;
         }
+
+        Undress();
 
         var uniformOutfit = jobUniform.GetOutfit(AvatarClothing);
         uniformOutfit.DressEntity(this);

--- a/code/player/Player.Jobs.cs
+++ b/code/player/Player.Jobs.cs
@@ -1,3 +1,4 @@
+using Cinema.Jobs;
 using Sandbox;
 
 namespace Cinema;
@@ -15,6 +16,24 @@ public partial class Player
 
         Components.RemoveAny<Jobs.PlayerJob>();
         Components.Add(Jobs.PlayerJob.CreateFromDetails(newJob));
+
+        if (Job.JobDetails.Uniform == null)
+        {
+            LoadAvatarClothing();
+            return;
+        }
+
+        var jobUniform = JobUniform.Get(Job.JobDetails.Uniform);
+        if (jobUniform == null)
+        {
+            Log.Error($"Could not find uniform with name: {Job.JobDetails.Uniform}");
+            return;
+        }
+
+        // Delete existing clothing so we don't overlap.
+        Undress();
+        var uniformOutfit = jobUniform.GetOutfit(AvatarClothing);
+        uniformOutfit.DressEntity(this);
     }
 
     /// <summary>

--- a/code/player/Player.cs
+++ b/code/player/Player.cs
@@ -78,7 +78,7 @@ partial class Player : AnimatedEntity, IEyes
         SetupBodyController();
         BodyController.Active = true;
 
-        LoadClothing();
+        LoadAvatarClothing();
 
         ClientRespawn(To.Single(Client));
     }

--- a/code/ui/hud/player_status/avatar/CitizenPanelScene.cs
+++ b/code/ui/hud/player_status/avatar/CitizenPanelScene.cs
@@ -1,4 +1,5 @@
-﻿using Sandbox;
+﻿using Cinema.Jobs;
+using Sandbox;
 using Sandbox.UI;
 
 namespace Cinema.UI;
@@ -45,6 +46,34 @@ public partial class CitizenPanelScene : ScenePanel
     {
         CitizenModel?.Delete();
         CitizenModel = null;
+    }
+
+    [CinemaEvent.JobChanged]
+    public void SetJobClothing(Player player)
+    {
+        if (player != Game.LocalPawn)
+            return;
+
+        InitScene();
+
+        var uniformName = player.Job.JobDetails.Uniform;
+
+        if (string.IsNullOrWhiteSpace(uniformName))
+        {
+            SetupClothing();
+        }
+        else
+        {
+            var uniformData = JobUniform.Get(uniformName);
+
+            if (uniformData != null)
+            {
+                CitizenClothing = uniformData.GetOutfit(CitizenClothing);
+            }
+        }
+
+        UpdateClothing();
+        RenderNextFrame();
     }
 
     private void SetupClothing()

--- a/code/ui/hud/player_status/avatar/CitizenPanelScene.cs
+++ b/code/ui/hud/player_status/avatar/CitizenPanelScene.cs
@@ -44,6 +44,7 @@ public partial class CitizenPanelScene : ScenePanel
 
     private void Cleanup()
     {
+        CitizenClothing.ClearEntities();
         CitizenModel?.Delete();
         CitizenModel = null;
     }
@@ -54,7 +55,7 @@ public partial class CitizenPanelScene : ScenePanel
         if (player != Game.LocalPawn)
             return;
 
-        InitScene();
+        Update();
 
         var uniformName = player.Job.JobDetails.Uniform;
 

--- a/code/util/ClothingContainer.cs
+++ b/code/util/ClothingContainer.cs
@@ -1,0 +1,247 @@
+﻿using Sandbox;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Cinema;
+
+/// <summary>
+/// Holds a collection of clothing items. Won't let you add items that aren't compatible.
+/// </summary>
+public class ClothingContainer
+{
+    public List<Clothing> Clothing = new();
+
+    /// <summary>
+    /// Add a clothing item if we don't already contain it, else remove it
+    /// </summary>
+    public void Toggle(Clothing clothing)
+    {
+        if (Has(clothing)) Remove(clothing);
+        else Add(clothing);
+    }
+
+    /// <summary>
+    /// Add clothing item
+    /// </summary>
+    public void Add(Clothing clothing)
+    {
+        Clothing.RemoveAll(x => !x.CanBeWornWith(clothing));
+        Clothing.Add(clothing);
+    }
+
+    /// <summary>
+    /// Add a clothing item without removing incompatible items.
+    /// </summary>
+    public void ForceAdd(Clothing clothing)
+    {
+        Clothing.Add(clothing);
+    }
+
+    /// <summary>
+    /// Load the clothing from this client's data. This is a different entry
+    /// point than just calling Deserialize directly because if we have
+    /// inventory based skins at some point, we can validate ownership here
+    /// </summary>
+    public void LoadFromClient(IClient cl)
+    {
+        var data = cl.GetClientData("avatar");
+        Deserialize(data);
+    }
+
+    /// <summary>
+    /// Remove clothing item
+    /// </summary>
+    public void Remove(Clothing clothing)
+    {
+        Clothing.Remove(clothing);
+    }
+
+    /// <summary>
+    /// Returns true if we have this clothing item
+    /// </summary>
+    public bool Has(Clothing clothing) => Clothing.Contains(clothing);
+
+    /// <summary>
+    /// Return a list of bodygroups and what their value should be
+    /// </summary>
+    public IEnumerable<(string name, int value)> GetBodyGroups()
+    {
+        var mask = Clothing.Select(x => x.HideBody).DefaultIfEmpty().Aggregate((a, b) => a | b);
+
+        yield return ("head", (mask & Sandbox.Clothing.BodyGroups.Head) != 0 ? 1 : 0);
+        yield return ("Chest", (mask & Sandbox.Clothing.BodyGroups.Chest) != 0 ? 1 : 0);
+        yield return ("Legs", (mask & Sandbox.Clothing.BodyGroups.Legs) != 0 ? 1 : 0);
+        yield return ("Hands", (mask & Sandbox.Clothing.BodyGroups.Hands) != 0 ? 1 : 0);
+        yield return ("Feet", (mask & Sandbox.Clothing.BodyGroups.Feet) != 0 ? 1 : 0);
+    }
+
+    /// <summary>
+    /// Serialize to Json
+    /// </summary>
+    public string Serialize()
+    {
+        return System.Text.Json.JsonSerializer.Serialize(Clothing.Select(x => new Entry { Id = x.ResourceId }));
+    }
+
+    /// <summary>
+    /// Deserialize from Json
+    /// </summary>
+    public void Deserialize(string json)
+    {
+        Clothing.Clear();
+
+        if (string.IsNullOrWhiteSpace(json))
+            return;
+
+        try
+        {
+            var entries = System.Text.Json.JsonSerializer.Deserialize<Entry[]>(json);
+
+            foreach (var entry in entries)
+            {
+                var item = ResourceLibrary.Get<Clothing>(entry.Id);
+                if (item == null) continue;
+                Add(item);
+            }
+        }
+        catch (System.Exception e)
+        {
+            Log.Warning(e, "Error deserailizing clothing");
+        }
+    }
+
+    /// <summary>
+    /// Used for serialization
+    /// </summary>
+    public struct Entry
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        // in the future we could allow some
+        // configuration (tint etc) of items
+        // which is why this is a struct instead
+        // of serializing an array of ints
+    }
+
+    List<AnimatedEntity> ClothingModels = new();
+
+    public void ClearEntities()
+    {
+        foreach (var model in ClothingModels)
+        {
+            model.Delete();
+        }
+        ClothingModels.Clear();
+    }
+
+    /// <summary>
+    /// Dress this citizen with clothes defined inside this class. We'll save the created entities in ClothingModels.
+    /// All clothing entities are tagged with "clothes".
+    /// </summary>
+    public void DressEntity(AnimatedEntity citizen, bool hideInFirstPerson = true, bool castShadowsInFirstPerson = true)
+    {
+        //
+        // Start with defaults
+        //
+        citizen.SetMaterialGroup("default");
+
+        //
+        // Remove old models
+        //
+        ClearEntities();
+
+        var SkinMaterial = Clothing.Select(x => x.SkinMaterial).Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => Material.Load(x)).FirstOrDefault();
+        var EyesMaterial = Clothing.Select(x => x.EyesMaterial).Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => Material.Load(x)).FirstOrDefault();
+
+        if (SkinMaterial != null) citizen.SetMaterialOverride(SkinMaterial, "skin");
+        if (EyesMaterial != null) citizen.SetMaterialOverride(EyesMaterial, "eyes");
+
+        //
+        // Create clothes models
+        //
+        foreach (var c in Clothing)
+        {
+            if (c.Model == "models/citizen/citizen.vmdl")
+            {
+                citizen.SetMaterialGroup(c.MaterialGroup);
+                continue;
+            }
+
+            var anim = new AnimatedEntity(c.Model, citizen);
+
+            anim.Tags.Add("clothes");
+
+            if (SkinMaterial != null) anim.SetMaterialOverride(SkinMaterial, "skin");
+            if (EyesMaterial != null) anim.SetMaterialOverride(EyesMaterial, "eyes");
+
+            anim.EnableHideInFirstPerson = hideInFirstPerson;
+            anim.EnableShadowInFirstPerson = castShadowsInFirstPerson;
+            anim.EnableTraceAndQueries = false;
+
+            if (!string.IsNullOrEmpty(c.MaterialGroup))
+                anim.SetMaterialGroup(c.MaterialGroup);
+
+            ClothingModels.Add(anim);
+        }
+
+        //
+        // Set body groups
+        //
+        foreach (var group in GetBodyGroups())
+        {
+            citizen.SetBodyGroup(group.name, group.value);
+        }
+    }
+
+    /// <summary>
+    /// Dress this citizen with clothes defined inside this class. We'll save the created entities in ClothingModels.
+    /// All clothing entities are tagged with "clothes".
+    /// </summary>
+    public List<SceneModel> DressSceneObject(SceneModel citizen)
+    {
+        var created = new List<SceneModel>();
+        var world = citizen.World;
+
+        //
+        // Start with defaults
+        //
+        citizen.SetMaterialGroup("default");
+        citizen.SetMaterialOverride(null);
+
+        var SkinMaterial = Clothing.Select(x => x.SkinMaterial).Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => Material.Load(x)).FirstOrDefault();
+        var EyesMaterial = Clothing.Select(x => x.EyesMaterial).Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => Material.Load(x)).FirstOrDefault();
+
+        if (SkinMaterial != null) citizen.SetMaterialOverride(SkinMaterial, "skin");
+        if (EyesMaterial != null) citizen.SetMaterialOverride(EyesMaterial, "eyes");
+
+        foreach (var c in Clothing)
+        {
+            if (string.IsNullOrEmpty(c.Model))
+                continue;
+
+            var model = Model.Load(c.Model);
+            var anim = new SceneModel(world, model, citizen.Transform);
+
+            created.Add(anim);
+
+            if (!string.IsNullOrEmpty(c.MaterialGroup))
+                anim.SetMaterialGroup(c.MaterialGroup);
+
+            citizen.AddChild("clothing", anim);
+
+            if (SkinMaterial != null) anim.SetMaterialOverride(SkinMaterial, "skin");
+            if (EyesMaterial != null) anim.SetMaterialOverride(EyesMaterial, "eyes");
+
+            anim.Update(0.1f);
+        }
+
+        foreach (var group in GetBodyGroups())
+        {
+            citizen.SetBodyGroup(group.name, group.value);
+        }
+
+        return created;
+    }
+}


### PR DESCRIPTION
This PR makes the following changes:

- Add custom event `CinemaEvent.JobChanged`, which runs on the server and clients whenever a `PlayerJob` component is activated.
- Add `JobUniform`, a `GameResource` that holds references to articles of `Clothing` that are applied at once to an NPC or player.
- Add `JobDetails.Uniform`, which specifies a `JobUniform` resource that shall be applied to a player working a particular job.
- Add `NpcBase.Uniform` to specify a `JobUniform` resource that shall be worn by an NPC on spawn. The default is `usher`.
- Make each `Player` wear the uniform associated with a job when they begin to work that job.
  - The change of outfit should also be reflected in `CitizenPanelScene`.
- On `Player`, rename `LoadClothing` to `LoadAvatarClothing` and `Clothing` to `AvatarClothing` to clarify that this refers to the clothing loaded from the client's avatar rather than the currently worn outfit.
- Copy `ClothingContainer` from the base library in to this project.
  - Made `Add` and `Remove` public. Add `ForceAdd` to allow for incompatible clothing articles to be worn at the same time in cases where we know best.
- Make entities that are spawned via `ent.create` face the player who spawned them.
- Set org to `cinemateam` in preparation of hosting on asset.party