### PR TITLE
Fix issue 65, add NoCollide

### DIFF
--- a/code/entities/Projectile.cs
+++ b/code/entities/Projectile.cs
@@ -6,6 +6,13 @@ namespace Cinema;
 public partial class Projectile : BasePhysics
 {
     /// <summary>
+    /// If true, food and drink items will automatically be removed from
+    /// a player's inventory after being thrown.
+    /// </summary>
+    [ConVar.Replicated("fnb.thrown.autoremove")]
+    public static bool AutoRemoveThrown { get; set; } = true;
+
+    /// <summary>
     /// In cases where it makes sense for a projectile to automatically break
     /// apart after being launched, this should be set to true.
     /// </summary>
@@ -45,6 +52,12 @@ public partial class Projectile : BasePhysics
     {
         Owner = entity;
         entity ??= this;
+
+        // Use nocollide hinge hack to work around issue where popcorn collides with seated thrower.
+        if (entity is Player ply && ply.ActiveController is ChairController)
+        {
+            NoCollide.BeginTimed(ply, this, 0.25f);
+        }
 
         var forward = entity.AimRay.Forward;
 

--- a/code/entities/Projectile.cs
+++ b/code/entities/Projectile.cs
@@ -20,13 +20,6 @@ public partial class Projectile : BasePhysics
     public static float NoCollideTime { get; set; } = 0.25f;
 
     /// <summary>
-    /// Defines the amount of time after a projectile is thrown by a standing player
-    /// that collisions will be ignored between the player and projectile.
-    /// </summary>
-    [ConVar.Replicated("fnb.thrown.ignorecollisiontime")]
-    public static float IgnoreCollisionTime { get; set; } = 0.25f;
-
-    /// <summary>
     /// In cases where it makes sense for a projectile to automatically break
     /// apart after being launched, this should be set to true.
     /// </summary>
@@ -51,8 +44,7 @@ public partial class Projectile : BasePhysics
         base.Spawn();
         SetupPhysicsFromModel(PhysicsMotionType.Dynamic);
 
-        // Remove the solid tag so that the projectile doesn't collide with the owner.
-        Tags.Remove("solid");
+        Tags.Add("projectile");
 
         // We assume that the projectile is in flight from the moment it is spawned.
         TimeSinceSpawned = 0f;
@@ -67,8 +59,8 @@ public partial class Projectile : BasePhysics
         Owner = entity;
         entity ??= this;
 
-        // Use nocollide hinge hack to work around issue where popcorn collides with a seated thrower.
-        if (entity is Player ply && ply.ActiveController is ChairController)
+        // Use nocollide hinge hack to work around issue where popcorn collides the thrower.
+        if (entity is Player)
         {
             NoCollide.BeginTimed(entity, this, NoCollideTime);
         }
@@ -97,10 +89,6 @@ public partial class Projectile : BasePhysics
     protected override void OnPhysicsCollision(CollisionEventData eventData)
     {
         lastCollision = eventData;
-
-        // Prevent the projectile from breaking on a player who is standing up.
-        if (TimeSinceSpawned <= IgnoreCollisionTime && eventData.Other.Entity == Owner)
-            return;
 
         // Don't break on the chair you're sitting in.
         if (eventData.Other.Entity is CinemaChair chair && chair.Occupant == Owner)

--- a/code/entities/Projectile.cs
+++ b/code/entities/Projectile.cs
@@ -53,11 +53,8 @@ public partial class Projectile : BasePhysics
         Owner = entity;
         entity ??= this;
 
-        // Use nocollide hinge hack to work around issue where popcorn collides with seated thrower.
-        if (entity is Player ply && ply.ActiveController is ChairController)
-        {
-            NoCollide.BeginTimed(ply, this, 0.25f);
-        }
+        // Use nocollide hinge hack to work around issue where popcorn collides with the thrower.
+        NoCollide.BeginTimed(entity, this, 0.25f);
 
         var forward = entity.AimRay.Forward;
 
@@ -83,10 +80,6 @@ public partial class Projectile : BasePhysics
     protected override void OnPhysicsCollision(CollisionEventData eventData)
     {
         lastCollision = eventData;
-
-        // Prevent the projectile from immediately breaking on the person who threw it.
-        if (TimeSinceSpawned < 0.25f && eventData.Other.Entity == Owner)
-            return;
 
         // Don't break on the chair you're sitting in.
         if (eventData.Other.Entity is CinemaChair chair && chair.Occupant == Owner)

--- a/code/entities/weapons/fnb/Hotdog.cs
+++ b/code/entities/weapons/fnb/Hotdog.cs
@@ -37,7 +37,8 @@ public partial class Hotdog : WeaponBase
 
             projectile.LaunchFromEntityViewpoint(WeaponHolder);
             
-            RemoveFromHolder();
+            if (Projectile.AutoRemoveThrown)
+                RemoveFromHolder();
         }
     }
 

--- a/code/entities/weapons/fnb/Nachos.cs
+++ b/code/entities/weapons/fnb/Nachos.cs
@@ -38,7 +38,8 @@ public partial class Nachos : WeaponBase
 
             projectile.LaunchFromEntityViewpoint(WeaponHolder);
             
-            RemoveFromHolder();
+            if (Projectile.AutoRemoveThrown)
+                RemoveFromHolder();
         }
     }
 

--- a/code/entities/weapons/fnb/Popcorn.cs
+++ b/code/entities/weapons/fnb/Popcorn.cs
@@ -37,7 +37,8 @@ public partial class Popcorn : WeaponBase
 
             projectile.LaunchFromEntityViewpoint(WeaponHolder);
             
-            RemoveFromHolder();
+            if (Projectile.AutoRemoveThrown)
+                RemoveFromHolder();
         }
     }
 

--- a/code/entities/weapons/fnb/Soda.cs
+++ b/code/entities/weapons/fnb/Soda.cs
@@ -37,7 +37,8 @@ public partial class Soda : WeaponBase
 
             projectile.LaunchFromEntityViewpoint(WeaponHolder);
             
-            RemoveFromHolder();
+            if (Projectile.AutoRemoveThrown)
+                RemoveFromHolder();
         }
     }
 

--- a/code/player/controllers/PlayerBodyController.cs
+++ b/code/player/controllers/PlayerBodyController.cs
@@ -173,6 +173,7 @@ public partial class PlayerBodyController : PlayerController, ISingletonComponen
             .Ray(start, end)
             .Size(mins, maxs)
             .WithAnyTags("solid", "playerclip", "passbullets")
+            .WithoutTags("projectile")
             .Ignore(Player)
             .Run();
 

--- a/code/util/NoCollide.cs
+++ b/code/util/NoCollide.cs
@@ -1,0 +1,76 @@
+﻿using Sandbox;
+using Sandbox.Physics;
+
+namespace Cinema;
+
+/// <summary>
+/// Allows for two entities to be made to not collide with each other.
+/// </summary>
+public static class NoCollide
+{
+    /// <summary>
+    /// Applies nocollide to the two specified entities by calling <c>Begin</c> and 
+    /// then calling <c>End</c> after the specified <paramref name="lifetimeInSeconds"/> elapses.
+    /// </summary>
+    /// <param name="first">An entity that shall be made to not collide with <paramref name="second"/>.</param>
+    /// <param name="second">An entity that shall be made to not collide with <paramref name="first"/>.</param>
+    /// <param name="lifetimeInSeconds">
+    /// The amount of time in seconds that will elapse before the nocollide constraint will automatically
+    /// be removed.
+    /// </param>
+    public static void BeginTimed(Entity first, Entity second, float lifetimeInSeconds)
+    {
+        if (lifetimeInSeconds <= 0f)
+            lifetimeInSeconds = Time.Delta;
+
+        var handle = Begin(first, second);
+        if (handle == null)
+            return;
+        
+        GameTask.RunInThreadAsync(async () =>
+        {
+            await GameTask.DelaySeconds(lifetimeInSeconds);
+            End(handle);
+        });
+    }
+
+    /// <summary>
+    /// Applies nocollide to the two specified entities. Returns a handle that can be used to
+    /// call <c>End</c> and allow the entities to collide once more.
+    /// </summary>
+    /// <param name="first">An entity that shall be made to not collide with <paramref name="second"/>.</param>
+    /// <param name="second">An entity that shall be made to not collide with <paramref name="first"/>.</param>
+    public static object Begin(Entity first, Entity second)
+    {
+        if (first.PhysicsGroup.BodyCount <= 0 || second.PhysicsGroup.BodyCount <= 0)
+        {
+            Log.Info($"{nameof(NoCollide)}: Entity has no physics body");
+            return null;
+        }
+            
+        var firstBody = first.PhysicsGroup.GetBody(0);
+        var secondBody = second.PhysicsGroup.GetBody(0);
+        var firstPoint = PhysicsPoint.Local(firstBody);
+        var secondPoint = PhysicsPoint.Local(secondBody);
+        return PhysicsJoint.CreateLength(firstPoint, secondPoint, float.PositiveInfinity);
+    }  
+    
+    /// <summary>
+    /// Ends the nocollide constraint between the two entities.
+    /// </summary>
+    /// <param name="handle">The handle that was returned by a call to <c>Begin</c>.</param>
+    public static void End(object handle)
+    {
+        if (handle is not PhysicsJoint physicsJoint)
+        {
+            Log.Info($"{nameof(NoCollide)}: {nameof(handle)} is not a PhysicsJoint");
+            return;
+        }
+        // Make sure these entities exist first before ending the no collide.
+        if (!physicsJoint.Body1.GetEntity().IsValid() || !physicsJoint.Body2.GetEntity().IsValid())
+        {
+            return;
+        }
+        physicsJoint.Remove();
+    }
+}

--- a/code/util/NoCollide.cs
+++ b/code/util/NoCollide.cs
@@ -66,11 +66,6 @@ public static class NoCollide
             Log.Info($"{nameof(NoCollide)}: {nameof(handle)} is not a PhysicsJoint");
             return;
         }
-        // Make sure these entities exist first before ending the no collide.
-        if (!physicsJoint.Body1.GetEntity().IsValid() || !physicsJoint.Body2.GetEntity().IsValid())
-        {
-            return;
-        }
         physicsJoint.Remove();
     }
 }


### PR DESCRIPTION
This PR has the following changes:
- Fix the issue where food will break instantly when thrown by a seated player
  - This fix is implemented through `NoCollide`.
  - The use of `NoCollide` also fixes an issue where physics impact sounds might play as soon as food is thrown.
- Add `NoCollide` utility class which creates physics joints between two entities to prevent them from colliding.
  - This is a hacky workaround to the inability to make two entities in S&box not collide with each other.
  - It is expected that Facepunch will eventually implement a "proper" solution to NoCollide for the Sandbox mode.
- Spawned projectiles now have a `projectile` tag added.
- `AntiStuck` now ignores projectiles.
  - This fixes jittery movement while throwing a projectile.