### PR TITLE
Always close MovieQueue via Player.CloseMenu

### DIFF
--- a/code/ui/movie-queue/MovieQueue.cs
+++ b/code/ui/movie-queue/MovieQueue.cs
@@ -184,7 +184,6 @@ public partial class MovieQueue : Panel, IMenuScreen
 
     protected void OnClose()
     {
-        IsOpen = false;
-        Controller = null;
+        (Game.LocalPawn as Player).CloseMenu(this);
     }
 }


### PR DESCRIPTION
This fixes: https://github.com/tech-nawar/sbox-cinema/issues/72

When I implemented the new menu system, I forgot to consider the case where MovieQueue could be closed by clicking on a button rather than pressing a key.