### PR TITLE
Add interact border

### DIFF
--- a/code/ui/hud/Hud.razor
+++ b/code/ui/hud/Hud.razor
@@ -8,6 +8,7 @@
     <Crosshair/>
     <PlayerCard />
     <InteractPrompt />
+    <InteractBorder />
     <StoreInterface />
     <div class="center">
         <ItemMenu />

--- a/code/ui/hud/interact/InteractBorder.razor
+++ b/code/ui/hud/interact/InteractBorder.razor
@@ -13,11 +13,7 @@
 @code {
     public string GetClass() => HoveredInteractable != null ? "visible" : "";
     public string GetFadeOutTime() => FadeOutTime.ToString();
-
-    private float FadeOutTime = 0.5f;
-    private TimeSince TimeSinceHoverEnd;
-    private Rect ScreenBounds { get; set; }
-    public Entity HoveredInteractable 
+    public Entity HoveredInteractable
     {
         get => _HoveredInteractable;
         set
@@ -34,7 +30,11 @@
         }
     }
     private Entity _HoveredInteractable;
+
     private BBox HoveredBounds;
+    private float FadeOutTime = 0.5f;
+    private TimeSince TimeSinceHoverEnd;
+    private Rect ScreenBounds { get; set; }
 
     public override void Tick()
     {
@@ -42,6 +42,8 @@
             ? ply.FindUsable(true) 
             : null;
 
+        // We don't stop tracking the interactable until the fade out is finished.
+        // This prevents the border from jumping around when the interactable is removed.
         if (HoveredInteractable == null && TimeSinceHoverEnd >= FadeOutTime)
             return;
 

--- a/code/ui/hud/interact/InteractBorder.razor
+++ b/code/ui/hud/interact/InteractBorder.razor
@@ -1,0 +1,60 @@
+﻿@using System;
+@using Sandbox;
+@using Sandbox.UI;
+@using Cinema;
+
+@attribute [StyleSheet]
+@inherits Panel;
+
+<root style="transition: opacity, @(GetFadeOutTime())s, ease-in;" class=@GetClass()>
+
+</root>
+
+@code {
+    public string GetClass() => HoveredInteractable != null ? "visible" : "";
+    public string GetFadeOutTime() => FadeOutTime.ToString();
+
+    private float FadeOutTime = 0.5f;
+    private TimeSince TimeSinceHoverEnd;
+    private Rect ScreenBounds { get; set; }
+    public Entity HoveredInteractable 
+    {
+        get => _HoveredInteractable;
+        set
+        {
+            if (_HoveredInteractable != null && value == null)
+            {
+                TimeSinceHoverEnd = 0;
+            }
+            _HoveredInteractable = value;
+            if (value != null)
+            {
+                HoveredBounds = value.WorldSpaceBounds;
+            }
+        }
+    }
+    private Entity _HoveredInteractable;
+    private BBox HoveredBounds;
+
+    public override void Tick()
+    {
+        HoveredInteractable = (Game.LocalPawn is Cinema.Player ply)
+            ? ply.FindUsable(true) 
+            : null;
+
+        if (HoveredInteractable == null && TimeSinceHoverEnd >= FadeOutTime)
+            return;
+
+        // Use fraction of screen size so that it works better with different resolution.
+        ScreenBounds = HoveredBounds.ToFractionalScreenBounds();
+        Style.Top = Length.Fraction(ScreenBounds.Top);
+        Style.Left = Length.Fraction(ScreenBounds.Left);
+        Style.Width = Length.Fraction(ScreenBounds.Width);
+        Style.Height = Length.Fraction(ScreenBounds.Height);
+    }
+
+    protected override int BuildHash()
+    {
+        return HashCode.Combine(ScreenBounds.Width, ScreenBounds.Height, ScreenBounds.TopLeft, ScreenBounds.BottomRight, HoveredInteractable);
+    }
+}

--- a/code/ui/hud/interact/InteractBorder.razor.scss
+++ b/code/ui/hud/interact/InteractBorder.razor.scss
@@ -1,0 +1,14 @@
+﻿InteractBorder {
+    position: absolute;
+    border-width: 2px;
+    border-color: white;
+    transition: opacity 0.15s ease-in;
+    
+    &.visible {
+        opacity: 0.4;
+    }
+
+    &:not(.visible) {
+        opacity: 0;
+    }
+}

--- a/code/ui/hud/interact/InteractBorder.razor.scss
+++ b/code/ui/hud/interact/InteractBorder.razor.scss
@@ -2,10 +2,12 @@
     position: absolute;
     border-width: 2px;
     border-color: white;
+    box-shadow: 2px 2px 20px 2px white;
+    border-radius: 10px;
     transition: opacity 0.15s ease-in;
-    
+
     &.visible {
-        opacity: 0.4;
+        opacity: 0.5;
     }
 
     &:not(.visible) {

--- a/code/util/ScreenHelper.cs
+++ b/code/util/ScreenHelper.cs
@@ -1,0 +1,36 @@
+﻿using Sandbox;
+using System;
+
+namespace Cinema;
+public static class ScreenHelper
+{
+    /// <summary>
+    /// Returns a screenspace 2D bounding box that tightly wraps the given worldspace
+    /// 3D bounding box. The returned bounding box is in fractions of screen size, so its
+    /// values may be used in <c>Panel</c> styles as <c>Length.Fraction</c>.
+    /// </summary>
+    /// <param name="bbox">A worldspace 3D bounding box.</param>
+    public static Rect ToFractionalScreenBounds(this BBox bbox)
+    {
+        float xLow = float.PositiveInfinity;
+        float xHigh = float.NegativeInfinity;
+        float yLow = float.PositiveInfinity;
+        float yHigh = float.NegativeInfinity;
+
+        foreach (var corner in bbox.Corners)
+        {
+            var screenPos = corner.ToScreen();
+            if (screenPos.x < xLow)
+                xLow = Math.Clamp(screenPos.x, 0, 1);
+            if (screenPos.x > xHigh)
+                xHigh = Math.Clamp(screenPos.x, 0, 1);
+            if (screenPos.y < yLow)
+                yLow = Math.Clamp(screenPos.y, 0, 1);
+            if (screenPos.y > yHigh)
+                yHigh = Math.Clamp(screenPos.y, 0, 1);
+        }
+        var width = xHigh - xLow;
+        var height = yHigh - yLow;
+        return new Rect(xLow, yLow, width, height);
+    }
+}


### PR DESCRIPTION
This PR adds a white border that appears around any entity that the player may interact with. This serves the purpose of making it easier for the player to understand which object is being hovered over in cases where many small objects (e.g. garbage, food) are close together. I've also added a `ScreenHelper` utility class since projecting a worldspace bounding box to screenspace might be useful for a lot of different things.