### PR TITLE
Add positional voice chat, local speaker icon

### DIFF
--- a/code/game/Game.Voice.cs
+++ b/code/game/Game.Voice.cs
@@ -1,0 +1,12 @@
+﻿using Sandbox;
+
+namespace Cinema;
+public partial class CinemaGame
+{
+    public override void OnVoicePlayed(IClient cl)
+    {
+        cl.Voice.WantsStereo = true;
+
+        base.OnVoicePlayed(cl);
+    }
+}

--- a/code/ui/hud/Hud.razor
+++ b/code/ui/hud/Hud.razor
@@ -13,5 +13,6 @@
         <ItemMenu />
     </div>
     <ChatBox />
+    <VoiceSpeaker/>
     <MovieQueue />
 </root>

--- a/code/ui/hud/Hud.scss
+++ b/code/ui/hud/Hud.scss
@@ -9,4 +9,10 @@ Hud {
         width: 100%;
         height: 100%;
     }
+
+    > VoiceSpeaker {
+        position: absolute;
+        right: 40px;
+        bottom: 160px;
+    }
 }


### PR DESCRIPTION
This PR enables positional audio for client voice chat and adds the base library VoiceSpeaker control to the HUD.

Known Issues:
- Voice chat audio is way too quiet. There is an issue for this: https://github.com/sboxgame/issues/issues/3468
- The citizen's mouth does not move. This also happens in Sandbox mode, so I assumed it was a bug and filed an issue: https://github.com/sboxgame/issues/issues/3469