### PR TITLE
Delete NameTag panel when pawn is destroyed

### DIFF
--- a/code/player/Player.UI.cs
+++ b/code/player/Player.UI.cs
@@ -98,4 +98,10 @@ public partial class Player
             ToggleMenu(MovieQueue.Instance);
         }
     }
+
+    private void CleanupUI()
+    {
+        // The nametag is a worldpanel, so it must be cleaned up manually.
+        HeadTag.Delete(true);
+    }
 }

--- a/code/player/Player.cs
+++ b/code/player/Player.cs
@@ -171,5 +171,15 @@ partial class Player : AnimatedEntity, IEyes
     {
         Footstepper.DoFootstep(position, foot, volume);
     }
-        
+
+    protected override void OnDestroy()
+    {
+        base.OnDestroy();
+
+        if (Game.IsServer)
+            return;
+
+        CleanupUI();
+    }
+
 }


### PR DESCRIPTION
This fixes: https://github.com/tech-nawar/sbox-cinema/issues/92